### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,7 +18,7 @@ require_once DOKU_PLUGIN.'syntax.php';
  */
 class action_plugin_dtable extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
 	    $controller->register_hook('DOKUWIKI_STARTED', 'AFTER',  $this, 'add_php_data');
 	    $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE',  $this, 'handle_ajax');
 	    $controller->register_hook('PARSER_WIKITEXT_PREPROCESS', 'AFTER',  $this, 'parser_preprocess_handler');

--- a/syntax.php
+++ b/syntax.php
@@ -31,7 +31,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
     function postConnect() { $this->Lexer->addExitPattern('</dtable>','plugin_dtable'); }
 
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
 		global $INFO;
         switch ($state) {
           case DOKU_LEXER_ENTER :
@@ -49,7 +49,7 @@ class syntax_plugin_dtable extends DokuWiki_Syntax_Plugin {
         return array();
     }
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
 	global $ID;
 	if($mode == 'xhtml')
 	{


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.